### PR TITLE
docs: set Source slice to make plugin compatible with ExtensionsExplorerPlugin

### DIFF
--- a/plugins/ace-Plugin.js
+++ b/plugins/ace-Plugin.js
@@ -3,7 +3,7 @@
 |Version |0.0.39 |
 |Version library |1.18.0 |
 |Description | |
-|Source |ace-Source |
+|Source |https://raw.githubusercontent.com/qbroker/ace-Plugin.js/master/plugins/ace-Plugin.js|
 |Documentation | |
 |Author |Okido |
 |Original author | |


### PR DESCRIPTION
Hey Okido!

Is it ok for you to set the Source slice so that EEP finds updates? Take a look at [docs](https://github.com/YakovL/TiddlyWiki_ExtensionsExplorerPlugin/blob/master/ExtensionsExplorerPlugin.js): I've added the "For extension authors: how to prepare extensions and repositories" section, hope it clarifies things if you get some questions (if it doesn't, let me know!).